### PR TITLE
adding tf fix

### DIFF
--- a/Demo/VPC/c3-vpc.tf
+++ b/Demo/VPC/c3-vpc.tf
@@ -11,17 +11,17 @@ module "vpc" {
   public_subnets  = var.public_subnet_cidr
 
   # Create a database subnet
-  create_database_subnet_group = var.create_database_subnet_group
-  create_database_subnet_route_table = var.create_database_subnet_route_table
+  create_database_subnet_group = true
+  create_database_subnet_route_table = true
   database_subnets = var.database_subnet_cidr
 
   # Enable NAT Gateway for our private subnets
-  enable_nat_gateway = var.enable_nat_gateway
-  single_nat_gateway = var.single_nat_gateway
+  enable_nat_gateway = true
+  single_nat_gateway = true
 
   # Enable DNS resolution
-  enable_dns_support = var.enable_dns_support
-  enable_dns_hostnames = var.enable_dns_hostnames
+  enable_dns_support = true
+  enable_dns_hostnames = true
 
   # Tagging of public & private subnets example
   public_subnet_tags = {


### PR DESCRIPTION
- [ ] Commented out the following inputs on `c2-vpc-mod.tf` file 

```t
# variable "create_database_subnet_group" {
#   description = "A boolean value to indicate whether a DB Subnet group is required."
#   type = bool
#   default = true
# }

# variable "create_database_subnet_route_table" {
#   description = "A boolean value to indicate whether a DB Subnet Route Table is required."
#   type = bool
#   default = true
# }

# variable "enable_nat_gateway" {
#   description = "A boolean value to indicate whether a NAT Gateway is required."
#   type = bool
#   default = true
# }

# variable "single_nat_gateway" {
#   description = "A boolean value to indicate whether a single NAT Gateway vs. multiple is required."
#   type = bool
#   default = true
# }


# variable "enable_dns_support" {
#   description = "A boolean value to indicate whether dns support is required."
#   type = bool
#   default = true
# }

# variable "enable_dns_hostnames" {
#   description = "A boolean value to indicate whether dns hostnames are required."
#   type = bool
#   default = true
# }
```

- [ ] modified `c3-vpc.tf` to hard code the boolean `true` vs using a `var.input` reference
```t
# Create a database subnet
  create_database_subnet_group = true
  create_database_subnet_route_table = true
  database_subnets = var.database_subnet_cidr

  # Enable NAT Gateway for our private subnets
  enable_nat_gateway = true
  single_nat_gateway = true

  # Enable DNS resolution
  enable_dns_support = true
  enable_dns_hostnames = true
```